### PR TITLE
adding asset tags for templates

### DIFF
--- a/VSIXProject2/source.extension.vsixmanifest
+++ b/VSIXProject2/source.extension.vsixmanifest
@@ -11,5 +11,8 @@
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
-  <Assets />
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="Output\ItemTemplates"/>
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="Output\ProjectTemplates" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
The asset tags were not added when templatebuilder was installed.

Can you:
 - [x] Open a bug in SW assigned to me to fix that with must-fix label
 - [ ] Add this to FAQ for common issues