### PR TITLE
Adding StartProgram/StartArguments directly in .csproj

### DIFF
--- a/VSIXProject2/VSIXProject2.csproj
+++ b/VSIXProject2/VSIXProject2.csproj
@@ -23,6 +23,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <StartProgram Condition=" '$(StartProgram)'=='' ">$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments Condition=" '$(StartArguments)'=='' ">/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -102,7 +104,8 @@
     <Content Include="ItemTemplates\SampleCategory\Bootstrap3BasicTemplate\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="TemplateBuilder">
+    <Reference Include="TemplateBuilder, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\TemplateBuilder.1.1.2-beta5\lib\TemplateBuilder.dll</HintPath>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Adding StartProgram/StartArguments directly in .csproj to ensure F5 works in team scenarios.

For more info, when you are working on a vsix project or vs package project when you create the project in the ```.csproj.user``` file the values for ```StartProgram``` and ```StartArguments``` are configured for that user. When the project is checked into source control those files are not included. So other users will have to go to the properties page and configure to launch ```devenv.exe``` to launch experimental instance themselves. To simplify that you can add the properties to the project itself like i have here.

@RandomlyKnighted can you mention this in the MSDN article and add to SideWaffle FAQ?